### PR TITLE
warning: implicit declaration of function 'kill'

### DIFF
--- a/include/exotic/cester.h
+++ b/include/exotic/cester.h
@@ -62,12 +62,18 @@ extern "C" {
     #define __CESTER_CAST_CHAR_ARRAY__
 #endif
 
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
+#define _POSIX_SOURCE
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+#endif
+
 #include <stdlib.h>
 #include <time.h>
 #include <stdio.h>
 #include <string.h>
 #ifndef CESTER_NO_SIGNAL
-#include <signal.h>
 #include <signal.h>
 #include <setjmp.h>
 jmp_buf buf;
@@ -105,12 +111,6 @@ jmp_buf buf;
     #endif
 #else
     #define EXOTIC_API
-#endif
-
-#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
-#include <unistd.h>
-#include <sys/wait.h>
-#include <sys/types.h>
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
During compilation the following warning occurs:
```/path/build/_deps/libcester-src/include/./exotic/cester.h: In function ‘cester_run_test’:
/path/build/_deps/libcester-src/include/./exotic/cester.h:3507:17: warning: implicit declaration of function ‘kill’ [-Wimplicit-function-declaration]
      |                 kill(pid, SIGTERM);
      |                 ^~~~
```

**kill** function is a part of POSIX feature API. Compiling it with ANSI standard requires to enable POSIX API feature by defining _POSIX_SOURCE.

Rationale:
1. C99 prohibits implicit declaration.
2. A lot of companies require -Wall -Werror flags to be pass also to dependencies as a part of SDL process.

My proposal:
1. Added _POSIX_SOURCE definition to the unix #ifdef block.
2. Moved unix #ifdef block above #include <signal.h> to affect this header file.
3. Additionally removed doubled (redundant?) include of signal.h

