### PR TITLE
Fix: Static sized memory buffer was overflowing.

### DIFF
--- a/include/exotic/cester.h
+++ b/include/exotic/cester.h
@@ -951,35 +951,46 @@ static __CESTER_INLINE__ void cester_str_value_after_first(char *arg, char from,
 }
 
 static __CESTER_INLINE__ void cester_concat_str(char **out, const char * extra) {
-    size_t concatted_pos = 0, index = 0;
-    char *concatted = (char*) malloc(sizeof(char) * 80000 );
-    if (extra == CESTER_NULL) {
-        extra = (char *) "(null)";
+
+    // if nothing to concatenate - do nothing
+    if (!extra) {
+        return;
     }
-    while (1) {
-        if ((*out) == CESTER_NULL || (*out)[index] == '\0') {
-            break;
-        }
-        concatted[concatted_pos] = (*out)[index];
-        concatted_pos++;
-        index++;
+
+    // no point doing anything if being asked to concatenate empty extra string
+    size_t extra_length = strlen(extra);
+    if (extra_length == 0) {
+        return;
     }
-    index = 0;
-    while (1) {
-        if (extra[index] == '\0') {
-            break;
-        }
-        concatted[concatted_pos] = extra[index];
-        concatted_pos++;
-        index++;
+
+    // get the length of the string being appended to
+    size_t original_length = 0;
+    if (*out) {
+        original_length = strlen(*out);
     }
-    concatted[concatted_pos] = '\0';
-    if (strlen(*out) > 0) {
+
+    // allocate the correct length
+    size_t new_length = original_length + extra_length;
+    char * concatted = (char *)malloc(sizeof(char) * new_length + 1);
+
+    // put the original string in the target
+    if (original_length > 0) {
+        strcpy(concatted, *out);
+    }
+    else {
+        concatted[0] = 0;
+    }
+
+    // append the extra string
+    strcat(concatted, extra);
+
+    // free the originals - if the string is empty, we assume
+    // that it is a non-malloced initializer and don't free it.
+    if (*out && *out[0] != 0) {
         free(*out);
     }
-    *out = (char*) malloc(concatted_pos+1);
-    cester_copy_str(&concatted, out, concatted_pos);
-    free(concatted);
+    // set the value
+    *out = concatted;
 }
 
 static __CESTER_INLINE__ void cester_concat_ptr(char **out, void *ptr) {

--- a/include/exotic/cester.h
+++ b/include/exotic/cester.h
@@ -952,44 +952,44 @@ static __CESTER_INLINE__ void cester_str_value_after_first(char *arg, char from,
 
 static __CESTER_INLINE__ void cester_concat_str(char **out, const char * extra) {
 
-    // if nothing to concatenate - do nothing
+    size_t extra_length;
+    size_t original_length;
+    size_t new_length;
+    char * concatted;
+
     if (!extra) {
-        return;
+        extra_length = 0;
+    }
+    else {
+        extra_length = strlen(extra);
     }
 
-    // no point doing anything if being asked to concatenate empty extra string
-    size_t extra_length = strlen(extra);
-    if (extra_length == 0) {
-        return;
-    }
-
-    // get the length of the string being appended to
-    size_t original_length = 0;
     if (*out) {
         original_length = strlen(*out);
     }
+    else {
+        original_length = 0;
+    }
 
-    // allocate the correct length
-    size_t new_length = original_length + extra_length;
-    char * concatted = (char *)malloc(sizeof(char) * new_length + 1);
+    new_length = original_length + extra_length;
+    concatted = (char *)malloc(sizeof(char) * new_length + 1);
 
-    // put the original string in the target
     if (original_length > 0) {
-        strcpy(concatted, *out);
+        strncpy(concatted, *out, original_length);
+        concatted[original_length] = 0;
     }
     else {
         concatted[0] = 0;
     }
 
-    // append the extra string
-    strcat(concatted, extra);
+    if (extra_length > 0) {
+        strncpy(concatted + original_length, extra, extra_length);
+        concatted[original_length + extra_length] = 0;
+    }
 
-    // free the originals - if the string is empty, we assume
-    // that it is a non-malloced initializer and don't free it.
     if (*out && *out[0] != 0) {
         free(*out);
     }
-    // set the value
     *out = concatted;
 }
 


### PR DESCRIPTION
When tests produced too much error output - the statically allocated buffer would overflow. Rewrote the offending routine to do dynamic allocation.
