### PR TITLE
Guard against __BASE_FILE__ not being in Include dir

### DIFF
--- a/include/exotic/cester.h
+++ b/include/exotic/cester.h
@@ -97,6 +97,12 @@ jmp_buf buf;
 #endif
 #endif
 
+#if defined __has_include
+    #if !__has_include (__BASE_FILE__)
+        #pragma message("__BASE_FILE__ is not in include directory. Add the option '-I.' for your compiler so it can find the file.")
+    #endif
+#endif
+
 #ifdef _WIN32
 #ifndef CESTER_EXCLUDE_WINDOWS_H
 #ifndef NOMINMAX


### PR DESCRIPTION
Print helpful message if user forget to add "-I." to compilation command on some compilers.
This will not work on all platforms, on my gcc it works but not on clang.
For documentation, see
https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html